### PR TITLE
remove uri encode

### DIFF
--- a/app/controllers/public/connect_controller.rb
+++ b/app/controllers/public/connect_controller.rb
@@ -12,7 +12,7 @@ class Public::ConnectController < ApplicationController
     if @database.campus_only? && !on_campus
       redirect root_path, error: I18n.t('campus_only')
     else
-      redirect_to URI.encode(url)
+      redirect_to url
     end
   end
 


### PR DESCRIPTION
URI.encode was causing a link to fail. It appears that the url is already encoded correctly and reencoding it adds extract characters into the url.

Removed URI.encode from connect_controller.rb and tested and is working correctly.

Note: It appears URL.encode has been deprecated. 
 
