### PR TITLE
Database csv url fix

### DIFF
--- a/app/models/database.rb
+++ b/app/models/database.rb
@@ -210,7 +210,7 @@ class Database < ApplicationRecord
 
       csv << attributes.map(&:better_titleize)
       all.find_each do |database|
-        database.url = database.connect_url if database.url
+        database.url = database.connect_url
         csv << attributes.map { |attr| database.send(attr) }
       end
     end

--- a/app/models/database.rb
+++ b/app/models/database.rb
@@ -192,6 +192,10 @@ class Database < ApplicationRecord
     access == 'Campus Only Access (No Proxy)'
   end
 
+  def connect_url
+     'https://databases.lib.wvu.edu/connect/' + url_uuid
+  end
+
   # Creates a csv object of all database records.
   # @author David J. Davis
   # @return csv object
@@ -206,6 +210,7 @@ class Database < ApplicationRecord
 
       csv << attributes.map(&:better_titleize)
       all.find_each do |database|
+        database.url = database.connect_url if database.url
         csv << attributes.map { |attr| database.send(attr) }
       end
     end

--- a/spec/models/database_spec.rb
+++ b/spec/models/database_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe Database, type: :model do
       databases = Database.all
       csv_string = databases.to_csv.to_s
       # attr to check
-      attributes = %w{id libguides_id name status years_of_coverage vendor_name url access full_text_db new_database trial_database access_plain_text help help_url description url_uuid popular trial_database trial_expiration_date title_search resources_column subject_column created_at updated_at}
+      attributes = %w{id libguides_id name status years_of_coverage vendor_name connect_url access full_text_db new_database trial_database access_plain_text help help_url description url_uuid popular trial_database trial_expiration_date title_search resources_column subject_column created_at updated_at}
       # run an expecatation for each attribute
       attributes.each do |attr|
         expect(csv_string).to include database[attr].to_s


### PR DESCRIPTION
# Database CSV Url Fix
Modified the Database Model to create a connect_url method which is generated a url that based on 'https://databases.lib.wvu.edu/connect/' + url_uuid in the model. This was requested instead of using the current url in the model.

## How Has This Been Tested?
Modified database_spec.rb test 'creates a csv report' to so that it looks for the new connect_url instead of the original url.