### PR TITLE
Updated test

### DIFF
--- a/spec/decorators/database_decorator_spec.rb
+++ b/spec/decorators/database_decorator_spec.rb
@@ -31,7 +31,7 @@ describe DatabaseDecorator do
       database.trial_database = false
       database.new_database = false
       database.save! 
-      expect(database.new_database ).to be false
+
       decorator = DatabaseDecorator.new(database).display_title
       expect(decorator).to be_a(String)
       expect(decorator).not_to  include 'popular-title'

--- a/spec/decorators/database_decorator_spec.rb
+++ b/spec/decorators/database_decorator_spec.rb
@@ -8,7 +8,8 @@ describe DatabaseDecorator do
   context ".display_title" do
     it 'db is popular expects the class popular-title to be added to the string' do
       database.popular = true
-      database.trial_database = false; 
+      database.trial_database = false
+      database.new_database = false 
       database.save! 
       decorator = DatabaseDecorator.new(database).display_title
       expect(decorator).to be_a(String)
@@ -17,7 +18,8 @@ describe DatabaseDecorator do
 
     it 'db is trial expects the class popular-title to be added to the string' do
       database.popular = false
-      database.trial_database = true; 
+      database.trial_database = true
+      database.new_database = false 
       database.save! 
       decorator = DatabaseDecorator.new(database).display_title
       expect(decorator).to be_a(String)
@@ -26,7 +28,8 @@ describe DatabaseDecorator do
 
     it 'db is neither expects the class popular-title is not added' do
       database.popular = false
-      database.trial_database = false; 
+      database.trial_database = false
+      database.new_database = false
       database.save! 
       decorator = DatabaseDecorator.new(database).display_title
       expect(decorator).to be_a(String)

--- a/spec/decorators/database_decorator_spec.rb
+++ b/spec/decorators/database_decorator_spec.rb
@@ -31,6 +31,7 @@ describe DatabaseDecorator do
       database.trial_database = false
       database.new_database = false
       database.save! 
+      expect(database.new_database ).to be false
       decorator = DatabaseDecorator.new(database).display_title
       expect(decorator).to be_a(String)
       expect(decorator).not_to  include 'popular-title'


### PR DESCRIPTION
# Updated Decorator Tests
removed ; and added database.new_database = false 
to 2 of the tests. This insures it is not being set randomly by the factory.

## Description
Test was failing due to database.new_database being set to true in the factory.

## Motivation and Context
Testing auto pr for loofah-2.3.1 this test was failing.

## How Has This Been Tested?
Locally tested rspec and through circleci. Tests are the only code changes.

## Screenshots (if appropriate):