### PR TITLE
database decorator and partial update

### DIFF
--- a/app/decorators/database_decorator.rb
+++ b/app/decorators/database_decorator.rb
@@ -13,8 +13,20 @@ class DatabaseDecorator < SimpleDelegator
       "<h3> #{link} </h3>".html_safe
     end 
   end 
+  
+  # Checks attributes title/open to format title
+  # @author Tracy A. McCormick
+  # @return [String] h3 with nested link  
+  def display_open_title
+    link = title_link
+    if open_access 
+      "<h3 class='open-title'> #{link} </h3>".html_safe
+    else
+      "<h3> #{link} </h3>".html_safe
+    end 
+  end 
 
-  # Creates a link to return to the display_title 
+  # Creates a link to return to the display_title and display_open_title
   # @author David J. Davis
   # @return [String] link
   def title_link

--- a/app/views/public/partials/_new_databases.html.erb
+++ b/app/views/public/partials/_new_databases.html.erb
@@ -3,7 +3,7 @@
     <% @new_databases.each do |db| %>
       <div class="database-results"> 
         <%= DatabaseDecorator.new(db).display_title %>
-        <p> <%= db.description.truncate(150) %> </p>
+        <p> <%= raw db.description.truncate(150) %> </p>
       </div>
     <% end %>
   </section>

--- a/app/views/public/partials/_open_access_databases.html.erb
+++ b/app/views/public/partials/_open_access_databases.html.erb
@@ -2,8 +2,8 @@
     <h2> Open Access </h2>
     <% @open_access.each do |db| %>
       <div class="database-results"> 
-        <%= DatabaseDecorator.new(db).display_title %>
-        <p> <%= db.description.truncate(150) %> </p>
+        <%= DatabaseDecorator.new(db).display_open_title %>
+        <p> <%= raw db.description.truncate(150) %> </p>
       </div>
     <% end %>
   </section>

--- a/app/views/public/partials/_popular.html.erb
+++ b/app/views/public/partials/_popular.html.erb
@@ -3,7 +3,7 @@
     <% @popular.each do |db| %>
       <div class="database-results"> 
         <%= DatabaseDecorator.new(db).display_title %>
-        <p> <%= db.description.truncate(150) %> </p>
+        <p> <%= raw db.description.truncate(150) %> </p>
       </div>
     <% end %>
   </section>

--- a/app/views/public/partials/_trials.html.erb
+++ b/app/views/public/partials/_trials.html.erb
@@ -3,7 +3,7 @@
     <% @trials.each do |db| %>
       <div class="database-results"> 
         <%= DatabaseDecorator.new(db).display_title %>
-        <p> <%= db.description.truncate(150) %> </p>
+        <p> <%= raw db.description.truncate(150) %> </p>
 
         <br/> 
         <strong> Trial ends on <%= l(db.trial_expiration_date, format: :human_readable) %> </strong>

--- a/spec/decorators/database_decorator_spec.rb
+++ b/spec/decorators/database_decorator_spec.rb
@@ -9,7 +9,8 @@ describe DatabaseDecorator do
     it 'db is popular expects the class popular-title to be added to the string' do
       database.popular = true
       database.trial_database = false
-      database.new_database = false 
+      database.new_database = false
+      database.open_access = false       
       database.save! 
       decorator = DatabaseDecorator.new(database).display_title
       expect(decorator).to be_a(String)
@@ -19,23 +20,55 @@ describe DatabaseDecorator do
     it 'db is trial expects the class popular-title to be added to the string' do
       database.popular = false
       database.trial_database = true
-      database.new_database = false 
+      database.new_database = false
+      database.open_access = false 
       database.save! 
       decorator = DatabaseDecorator.new(database).display_title
       expect(decorator).to be_a(String)
       expect(decorator).to  include 'popular-title'
     end 
 
+    it 'db is open access expects the class open-title to be added to the string' do
+      database.popular = false
+      database.trial_database = false
+      database.new_database = false 
+      database.open_access = true
+      database.save! 
+      decorator = DatabaseDecorator.new(database).display_title
+      expect(decorator).to be_a(String)
+      expect(decorator).to  include 'open-title'
+    end  
+    
     it 'db is neither expects the class popular-title is not added' do
       database.popular = false
       database.trial_database = false
       database.new_database = false
+      database.open_access = false
       database.save! 
 
       decorator = DatabaseDecorator.new(database).display_title
       expect(decorator).to be_a(String)
       expect(decorator).not_to  include 'popular-title'
     end 
+  end
+
+  context ".display_open_title" do
+    it 'db is open access expects the class open-title to be added to the string' do
+      database.open_access = true
+      database.save! 
+      decorator = DatabaseDecorator.new(database).display_open_title
+      expect(decorator).to be_a(String)
+      expect(decorator).to  include 'open-title'
+    end 
+
+    it 'db is not open_access expects the class open-title not to be added' do
+      database.open_access = false
+      database.save! 
+
+      decorator = DatabaseDecorator.new(database).display_open_title
+      expect(decorator).to be_a(String)
+      expect(decorator).not_to  include 'open-title'
+    end     
   end
 
   context ".landing_page?" do


### PR DESCRIPTION
# Database Decorator and Partial Update
    - Added raw to db.description.truncate(150) in multiple partials
    - created display_open_title in database_decorator.rb

# Files Changed
- app/decorators/database_decorator.rb
- app/views/public/partials/_new_databases.html.erb
- app/views/public/partials/_open_access_databases.html.erb
- app/views/public/partials/_popular.html.erb
- app/views/public/partials/_trials.html.erb
- spec/decorators/database_decorator_spec.rb

## Description
Adjusted partials added the raw statement to description to properly show the & symbol. Created new method in the database_decorator.rb to correctly show the icon for open_access section of the main page.

## Related Issue
No issue was created issues were directly emailed to me.

## How Has This Been Tested?
Rspec tests were written for the changes in the decorator. Manual testing was done on the partials to insure they were displaying the & symbol correctly.

## Screenshots (if appropriate):