### PR TITLE
checked for gem vulnerabilities and fixed a bug in search box

### DIFF
--- a/databases/Gemfile
+++ b/databases/Gemfile
@@ -1,16 +1,17 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
 ruby '3.4.3'
 
 # Rails Dependencies
 # =====================================================
 # Rails, MySQL, Puma
-gem "rails", "~> 7.1.3"
+# gem "rails", "~> 7.1.3"
+gem "rails", "~> 7.1.5", ">= 7.1.5.2"
 gem 'bundler'
-gem 'rake', '~> 13.1.0'
+gem 'rake', '~> 13.4'
 gem 'mysql2', '>= 0.4.4', '< 0.6.0'
 gem 'puma', '~> 6.4.0'
+gem 'rack', '>= 3.2.6'
 
 # JavaScript/Asset Dependencies
 gem 'jquery-rails'
@@ -53,6 +54,11 @@ gem 'bootsnap', '>= 1.4.2', require: false
 # =====================================================================================
 # cas client
 gem 'rack-cas'
+
+gem 'faraday', '>= 2.14.1'
+gem 'nokogiri', '>= 1.19.1'
+gem 'rexml', '>= 3.4.2'
+gem 'uri', '>= 1.0.4'
 
 # session store
 gem 'activerecord-session_store'
@@ -111,9 +117,10 @@ group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen'
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-watcher-listen', '~> 2.1'
   # performance helper
   gem 'bullet' # helps to eliminate N+1 Queries 
+  gem 'bundler-audit'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/databases/Gemfile.lock
+++ b/databases/Gemfile.lock
@@ -1,35 +1,36 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.1.5.1)
-      actionpack (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
+    actioncable (7.1.6)
+      actionpack (= 7.1.6)
+      activesupport (= 7.1.6)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
-    actionmailbox (7.1.5.1)
-      actionpack (= 7.1.5.1)
-      activejob (= 7.1.5.1)
-      activerecord (= 7.1.5.1)
-      activestorage (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
+    actionmailbox (7.1.6)
+      actionpack (= 7.1.6)
+      activejob (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
       mail (>= 2.7.1)
       net-imap
       net-pop
       net-smtp
-    actionmailer (7.1.5.1)
-      actionpack (= 7.1.5.1)
-      actionview (= 7.1.5.1)
-      activejob (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
+    actionmailer (7.1.6)
+      actionpack (= 7.1.6)
+      actionview (= 7.1.6)
+      activejob (= 7.1.6)
+      activesupport (= 7.1.6)
       mail (~> 2.5, >= 2.5.4)
       net-imap
       net-pop
       net-smtp
       rails-dom-testing (~> 2.2)
-    actionpack (7.1.5.1)
-      actionview (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
+    actionpack (7.1.6)
+      actionview (= 7.1.6)
+      activesupport (= 7.1.6)
+      cgi
       nokogiri (>= 1.8.5)
       racc
       rack (>= 2.2.4)
@@ -37,27 +38,28 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    actiontext (7.1.5.1)
-      actionpack (= 7.1.5.1)
-      activerecord (= 7.1.5.1)
-      activestorage (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
+    actiontext (7.1.6)
+      actionpack (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (7.1.5.1)
-      activesupport (= 7.1.5.1)
+    actionview (7.1.6)
+      activesupport (= 7.1.6)
       builder (~> 3.1)
+      cgi
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activejob (7.1.5.1)
-      activesupport (= 7.1.5.1)
+    activejob (7.1.6)
+      activesupport (= 7.1.6)
       globalid (>= 0.3.6)
-    activemodel (7.1.5.1)
-      activesupport (= 7.1.5.1)
-    activerecord (7.1.5.1)
-      activemodel (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
+    activemodel (7.1.6)
+      activesupport (= 7.1.6)
+    activerecord (7.1.6)
+      activemodel (= 7.1.6)
+      activesupport (= 7.1.6)
       timeout (>= 0.4.0)
     activerecord-session_store (2.2.0)
       actionpack (>= 7.0)
@@ -65,13 +67,13 @@ GEM
       cgi (>= 0.3.6)
       rack (>= 2.0.8, < 4)
       railties (>= 7.0)
-    activestorage (7.1.5.1)
-      actionpack (= 7.1.5.1)
-      activejob (= 7.1.5.1)
-      activerecord (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
+    activestorage (7.1.6)
+      actionpack (= 7.1.6)
+      activejob (= 7.1.6)
+      activerecord (= 7.1.6)
+      activesupport (= 7.1.6)
       marcel (~> 1.0)
-    activesupport (7.1.5.1)
+    activesupport (7.1.6)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -99,6 +101,9 @@ GEM
     bullet (8.0.8)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     byebug (12.0.0)
     capybara (3.40.0)
       addressable
@@ -168,7 +173,7 @@ GEM
       railties (>= 6.1.0)
     faker (3.5.2)
       i18n (>= 1.8.11, < 2)
-    faraday (2.13.4)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -249,7 +254,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.9-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
     non-stupid-digest-assets (1.0.11)
       sprockets (>= 2.0)
@@ -272,7 +277,7 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.0)
+    rack (3.2.6)
     rack-cas (0.16.1)
       addressable (~> 2.3)
       nokogiri (~> 1.5)
@@ -287,20 +292,20 @@ GEM
       rack (>= 1.0.0)
     rackup (2.2.1)
       rack (>= 3)
-    rails (7.1.5.1)
-      actioncable (= 7.1.5.1)
-      actionmailbox (= 7.1.5.1)
-      actionmailer (= 7.1.5.1)
-      actionpack (= 7.1.5.1)
-      actiontext (= 7.1.5.1)
-      actionview (= 7.1.5.1)
-      activejob (= 7.1.5.1)
-      activemodel (= 7.1.5.1)
-      activerecord (= 7.1.5.1)
-      activestorage (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
+    rails (7.1.6)
+      actioncable (= 7.1.6)
+      actionmailbox (= 7.1.6)
+      actionmailer (= 7.1.6)
+      actionpack (= 7.1.6)
+      actiontext (= 7.1.6)
+      actionview (= 7.1.6)
+      activejob (= 7.1.6)
+      activemodel (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
       bundler (>= 1.15.0)
-      railties (= 7.1.5.1)
+      railties (= 7.1.6)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
@@ -312,15 +317,17 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    railties (7.1.5.1)
-      actionpack (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
+    railties (7.1.6)
+      actionpack (= 7.1.6)
+      activesupport (= 7.1.6)
+      cgi
       irb
       rackup (>= 1.0.0)
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
       zeitwerk (~> 2.6)
-    rake (13.1.0)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -331,7 +338,7 @@ GEM
     regexp_parser (2.11.1)
     reline (0.6.2)
       io-console (~> 0.5)
-    rexml (3.4.1)
+    rexml (3.4.4)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -392,10 +399,10 @@ GEM
     simplecov-html (0.13.2)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
-    spring (2.1.1)
-    spring-watcher-listen (2.0.1)
+    spring (4.5.0)
+    spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
+      spring (>= 4)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -413,6 +420,7 @@ GEM
     thor (1.4.0)
     tilt (2.6.1)
     timeout (0.4.3)
+    tsort (0.2.0)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -424,7 +432,7 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uniform_notifier (1.17.0)
-    uri (1.0.3)
+    uri (1.1.1)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
@@ -455,6 +463,7 @@ DEPENDENCIES
   bootstrap (~> 5.3.0)
   bullet
   bundler
+  bundler-audit
   byebug
   capybara (>= 2.15, < 4.0)
   carrierwave (~> 2.2)
@@ -469,6 +478,7 @@ DEPENDENCIES
   executables
   factory_bot_rails
   faker
+  faraday (>= 2.14.1)
   figaro
   jbuilder (~> 2.5)
   jquery-rails
@@ -478,18 +488,21 @@ DEPENDENCIES
   logging (~> 2.3)
   mutex_m
   mysql2 (>= 0.4.4, < 0.6.0)
+  nokogiri (>= 1.19.1)
   non-stupid-digest-assets
   normalize-scss
   ostruct
   pry
   pry-rails
   puma (~> 6.4.0)
+  rack (>= 3.2.6)
   rack-cas
   rack_session_access
-  rails (~> 7.1.3)
+  rails (~> 7.1.5, >= 7.1.5.2)
   rails-controller-testing
-  rake (~> 13.1.0)
+  rake (~> 13.4)
   recaptcha (~> 5.15)
+  rexml (>= 3.4.2)
   rspec-rails
   rspec_junit_formatter
   sanitize
@@ -501,13 +514,14 @@ DEPENDENCIES
   simplecov-console
   simplecov-lcov
   spring
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen (~> 2.1)
   sprockets-rails
   stringio
   syslog
   turbolinks (~> 5.2.0)
   tzinfo-data
   uglifier (>= 1.3.0)
+  uri (>= 1.0.4)
   validate_url
   web-console (>= 3.3.0)
   whenever

--- a/databases/app/views/public/search/_search_bar.html.erb
+++ b/databases/app/views/public/search/_search_bar.html.erb
@@ -3,7 +3,7 @@
     Search Databases
   </label>
   
-  <input type="search" name="query" title="Search Query" placeholder="Databases by Name... " class="search-field" id="<%= unique_id %>">
+  <input type="search" name="query" title="Search Query" placeholder="Databases by Name... " class="search-field" id="<%= unique_id %>" required>
   
   <button class="search-button button">
     <span class="fa fa-search"></span> 


### PR DESCRIPTION
# Gem Updates, Security Patches, and Search Fix
Description

Updated rake to ~> 13.4 and spring-watcher-listen to ~> 2.1
Added explicit gem constraints for rack, faraday, nokogiri, rexml, and uri to address security vulnerabilities
Added required attribute to search input to prevent empty search submissions

Related Issue
Routine dependency maintenance and security patch check.
Motivation and Context
bundle audit flagged several gems with known CVEs, primarily around DoS vulnerabilities in rack and SSRF in faraday. Search box was throwing an error on empty submissions.
How Has This Been Tested?

Rebuilt Docker container and verified gem versions via bundle list
Ran full RSpec test suite — all tests passing
Manually tested search box with empty input — browser now prevents submission